### PR TITLE
Migrated Telemetry Report tests from the siddhi-io-udp project

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -46,6 +46,49 @@
             <artifactId>siddhi-query-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.cablelabs</groupId>
+            <artifactId>siddhi-io-udp</artifactId>
+            <version>master-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi.extension.io.kafka</groupId>
+            <artifactId>siddhi-io-kafka</artifactId>
+            <version>5.0.12</version>
+            <type>bundle</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi.extension.io.file</groupId>
+            <artifactId>siddhi-io-file</artifactId>
+            <version>2.0.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi.extension.map.text</groupId>
+            <artifactId>siddhi-map-text</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi.extension.map.binary</groupId>
+            <artifactId>siddhi-map-binary</artifactId>
+            <version>2.1.0</version>
+            <type>bundle</type>
+        </dependency>
+        <dependency>
+            <groupId>io.siddhi.extension.map.json</groupId>
+            <artifactId>siddhi-map-json</artifactId>
+            <version>5.2.1</version>
+            <type>bundle</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
         </dependency>
@@ -84,18 +127,24 @@
         </profile>
     </profiles>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <suiteXmlFiles>-->
-<!--                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>-->
-<!--                    </suiteXmlFiles>-->
-<!--                    <argLine>${surefireArgLine} -ea -Xmx512m</argLine>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/component/src/main/java/io/siddhi/extension/map/p4/trpt/sourcemapper/P4TrptJsonStringSourceMapper.java
+++ b/component/src/main/java/io/siddhi/extension/map/p4/trpt/sourcemapper/P4TrptJsonStringSourceMapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Cable Television Laboratories, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.siddhi.extension.map.p4.trpt.sourcemapper;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.siddhi.annotation.Example;
+import io.siddhi.annotation.Extension;
+import io.siddhi.core.exception.MappingFailedException;
+import io.siddhi.core.stream.input.source.InputEventHandler;
+import io.siddhi.extension.map.json.sourcemapper.JsonSourceMapper;
+
+
+/**
+ * Custom mapper for P4 TRPT JSON strings by extending the base JSON mapper.
+ */
+@Extension(
+        name = "p4-trpt-json",
+        namespace = "sourceMapper",
+        description = "This extension is a P4 TRPT JSON-to-Event input mapper. Transports that accept these messages" +
+                " can utilize this extension,",
+        examples = {
+                @Example(
+                        syntax = "@map(type='p4-trpt-json')",
+                        description = "Best when used with kafka plugin sending Telemetry Report JSON"
+                )
+        }
+)
+
+public class P4TrptJsonStringSourceMapper extends JsonSourceMapper {
+
+    private final JsonParser parser = new JsonParser();
+
+    @Override
+    protected void mapAndProcess(Object eventObject, InputEventHandler inputEventHandler)
+            throws MappingFailedException, InterruptedException {
+
+        if (eventObject instanceof String) {
+            final JsonObject json = (JsonObject) parser.parse((String) eventObject);
+            final JsonObject eventJson = json.getAsJsonObject("event");
+            if (eventJson == null) {
+                throw new MappingFailedException("Incoming JSON's root element is not 'event'");
+            }
+            final JsonElement telemRpt = eventJson.get("telemRpt");
+            if (telemRpt == null) {
+                throw new MappingFailedException("Incoming JSON's 'event' element does not contain 'telemRpt'");
+            }
+            final String telemRptStr = telemRpt.toString();
+            String telemRptStrCleansed = telemRptStr.replace("\\\"", "\"");
+            telemRptStrCleansed = telemRptStrCleansed.substring(1);
+            telemRptStrCleansed = telemRptStrCleansed.substring(0, telemRptStrCleansed.length() - 1);
+            super.mapAndProcess(telemRptStrCleansed, inputEventHandler);
+        }
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/map/p4/TestTelemetryReports.java
+++ b/component/src/test/java/io/siddhi/extension/map/p4/TestTelemetryReports.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package io.siddhi.extension.map.p4.trpt.sourcemapper;
+package io.siddhi.extension.map.p4;
 
 /**
  * Describes the bytes held within the body of a Telemetry Report UDP Packet.

--- a/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/KafkaRunnable.java
+++ b/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/KafkaRunnable.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Cable Television Laboratories, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.siddhi.extension.map.p4.trpt.sourcemapper;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Class for listening to Kafka topics.
+ */
+class KafkaRunnable implements Runnable {
+
+    final Consumer<Long, String> consumer;
+    int numRecordsCount = 0;
+    final List<String> events = new ArrayList<>();
+
+    KafkaRunnable(final Consumer<Long, String> consumer) {
+        this.consumer = consumer;
+    }
+
+    private volatile boolean running = true;
+
+    public void stop() {
+        running = false;
+    }
+
+    @Override
+    public void run() {
+        while (running) {
+            final ConsumerRecords<Long, String> consumerRecords = consumer.poll(Duration.ofMillis(10));
+            if (consumerRecords.count() != 0) {
+                numRecordsCount += consumerRecords.count();
+                consumerRecords.forEach(record -> {
+                    System.out.printf("Consumer Record:(%d, %s, %d, %d)\n",
+                            record.key(), record.value(),
+                            record.partition(), record.offset());
+                    events.add(record.value());
+                });
+            }
+            consumer.commitSync();
+        }
+        consumer.close();
+    }
+
+    public static KafkaRunnable runConsumer(final String kafkaServer, final String topic) {
+        final Consumer<Long, String> consumer = createConsumer(kafkaServer, topic);
+        final KafkaRunnable out = new KafkaRunnable(consumer);
+        final Thread kafkaConsumerThread = new Thread(out);
+        kafkaConsumerThread.start();
+        return out;
+    }
+
+    private static Consumer<Long, String> createConsumer(final String kafkaServer, final String topic) {
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG,
+                "UDPSourceKafkaSinkTelemetryReportTestCase-" + System.currentTimeMillis());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+        // Create the consumer using props.
+        final Consumer<Long, String> consumer = new KafkaConsumer<>(props);
+
+        // Subscribe to the topic.
+        consumer.subscribe(Collections.singletonList(topic));
+        return consumer;
+    }
+
+}

--- a/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/TelemetryReportByteParsingTests.java
+++ b/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/TelemetryReportByteParsingTests.java
@@ -17,6 +17,7 @@ package io.siddhi.extension.map.p4.trpt.sourcemapper;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import io.siddhi.extension.map.p4.TestTelemetryReports;
 import io.siddhi.extension.map.p4.trpt.IntEthernetHeader;
 import io.siddhi.extension.map.p4.trpt.IntHeader;
 import io.siddhi.extension.map.p4.trpt.IntMetadataHeader;

--- a/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/UDPSourceKafkaSinkTelemetryReportTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/UDPSourceKafkaSinkTelemetryReportTestCase.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2021 Cable Television Laboratories, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.siddhi.extension.map.p4.trpt.sourcemapper;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.extension.map.p4.TestTelemetryReports;
+import io.siddhi.extension.map.p4.trpt.TelemetryReportHeader;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+
+/**
+ * Tests for the UDP Source extension with the p4-trpt mapper to ensure that the events get sent out to Kafka.
+ * This test case sends mock Telemetry report UDP packets to this UDP source Siddhi extension and ensures each of the
+ * resulting JSON documents contains the expected values.
+ */
+public class UDPSourceKafkaSinkTelemetryReportTestCase {
+    // If you will know about this related testcase,
+    //refer https://github.com/siddhi-io/siddhi-io-file/blob/master/component/src/test
+
+    private static final Logger log = Logger.getLogger(UDPSourceKafkaSinkTelemetryReportTestCase.class);
+    private SiddhiAppRuntime siddhiAppRuntime;
+    private List<Event[]> events;
+    private String testTopic;
+    private KafkaRunnable consumerRunnable;
+    private static final String kafkaServer = "wso2-vm:9092";
+
+    @BeforeMethod
+    public void setUp() {
+        log.info("In setUp()");
+        events = new ArrayList<>();
+        testTopic = UUID.randomUUID().toString();
+
+        final String inStreamDefinition = String.format(
+                "@app:name('Kafka-Sink-TRPT')\n" +
+                "@source(type='udp', listen.port='5556', @map(type='p4-trpt'))\n" +
+                "@sink(type='kafka', topic='%s', bootstrap.servers='%s'," +
+                    "@map(type='text'))\n" +
+                "define stream trptUdpPktStream (trptJson OBJECT);\n", testTopic, kafkaServer);
+        final String query =
+                "@info(name = 'query1')\n" +
+                "from trptUdpPktStream\n" +
+                "select *\n" +
+                "insert into outputStream;";
+        final SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                events.add(inEvents);
+            }
+        });
+        siddhiAppRuntime.start();
+        consumerRunnable = KafkaRunnable.runConsumer(kafkaServer, testTopic);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        log.info("In tearDown()");
+        consumerRunnable.stop();
+
+        try {
+            siddhiAppRuntime.shutdown();
+        } finally {
+            // Delete topic
+            final Properties conf = new Properties();
+            conf.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+            conf.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "5000");
+            final AdminClient client = AdminClient.create(conf);
+            log.info("Deleting testTopic - " + testTopic);
+            client.deleteTopics(Collections.singletonList(testTopic));
+            client.close();
+        }
+
+        log.info("Siddhi App Runtime down");
+    }
+
+    /**
+     * Tests to ensure that UDP IPv4 two hop Telemetry Report packets can be converted to JSON and sent out via Kafka.
+     */
+    @Test
+    public void testTelemetryReportUdp4() {
+        runTest(TestTelemetryReports.UDP4_2HOPS);
+    }
+
+    /**
+     * Tests to ensure that TCP IPv4 two hop Telemetry Report packets can be converted to JSON and sent out via Kafka.
+     */
+    @Test
+    public void testTelemetryReportTcp4() {
+        runTest(TestTelemetryReports.TCP4_2HOPS);
+    }
+
+    /**
+     * Tests to ensure that UDP IPv6 two hop Telemetry Report packets can be converted to JSON and sent out via Kafka.
+     */
+    @Test
+    public void testTelemetryReportUdp6() {
+        runTest(TestTelemetryReports.UDP6_2HOPS);
+    }
+
+    /**
+     * Tests to ensure that TCP IPv4 two hop Telemetry Report packets can be converted to JSON and sent out via Kafka.
+     */
+    @Test
+    public void testTelemetryReportTcp6() {
+        runTest(TestTelemetryReports.TCP6_2HOPS);
+    }
+
+    private void runTest(final byte[] bytes) {
+        final int numTestEvents = 50;
+        try {
+            sendTestEvents(bytes, numTestEvents);
+
+            // Wait a sec for the processing to complete
+            Thread.sleep(1000);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        validateTelemetryReports();
+
+        Assert.assertEquals(consumerRunnable.events.size(), consumerRunnable.numRecordsCount);
+
+        // TODO - Determine why all are not always received by the Kafka Consumer, KafkaRunnable
+        Assert.assertTrue(consumerRunnable.numRecordsCount <= numTestEvents);
+        Assert.assertTrue(consumerRunnable.events.size() <= numTestEvents);
+    }
+
+    private void sendTestEvents(final byte[] eventBytes, final int numTestEvents) throws Exception {
+        for (int ctr = 0; ctr < numTestEvents; ctr++) {
+            final InetAddress address = InetAddress.getByName("localhost");
+            final DatagramPacket packet = new DatagramPacket(eventBytes, 0, eventBytes.length,
+                    address, 5556);
+            // TODO - need to get this
+            // configReader.readConfig(KEEP_ALIVE, "" + Constant.DEFAULT_KEEP_ALIVE)
+            final DatagramSocket datagramSocket = new DatagramSocket();
+            datagramSocket.send(packet);
+            Thread.sleep(1, 10000);
+        }
+    }
+
+    private void validateTelemetryReports() {
+        for (final String eventStr : consumerRunnable.events) {
+            final JsonParser parser = new JsonParser();
+            final JsonElement jsonElement = parser.parse(eventStr.replaceAll("trptJson:", ""));
+            final JsonObject trptJsonObj = jsonElement.getAsJsonObject();
+            Assert.assertNotNull(trptJsonObj);
+            final JsonObject trptHdrJson = trptJsonObj.get("telemRptHdr").getAsJsonObject();
+            Assert.assertNotNull(trptHdrJson);
+            Assert.assertEquals(2, trptHdrJson.get(TelemetryReportHeader.TRPT_VER_KEY).getAsInt());
+            Assert.assertEquals(234, trptHdrJson.get(TelemetryReportHeader.TRPT_NODE_ID_KEY).getAsLong());
+            Assert.assertEquals(21587, trptHdrJson.get(TelemetryReportHeader.TRPT_DOMAIN_ID_KEY).getAsLong());
+        }
+    }
+
+}

--- a/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/UDPSourceToKafkaSourceTelemetryReportTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/map/p4/trpt/sourcemapper/UDPSourceToKafkaSourceTelemetryReportTestCase.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2021 Cable Television Laboratories, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.siddhi.extension.map.p4.trpt.sourcemapper;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.extension.map.p4.TestTelemetryReports;
+import io.siddhi.extension.map.p4.trpt.TelemetryReportHeader;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+
+/**
+ * Tests for the UDP Source extension with the p4-trpt mapper to ensure that the events get sent out to Kafka with
+ * "json" mapping and received by the kafka source with "json" mapping.
+ */
+public class UDPSourceToKafkaSourceTelemetryReportTestCase {
+    // If you will know about this related testcase,
+    //refer https://github.com/siddhi-io/siddhi-io-file/blob/master/component/src/test
+
+    private static final Logger log = Logger.getLogger(UDPSourceToKafkaSourceTelemetryReportTestCase.class);
+    private SiddhiAppRuntime srcUdpSiddhiAppRuntime;
+    private SiddhiAppRuntime kafkaIngressSiddhiAppRuntime;
+    private List<Event[]> parsedUdpEvents;
+    private List<Event[]> kafkaIngressEvents;
+    private String testTopic;
+    private final String kafkaServer = "wso2-vm:9092";
+    private static final int numTestEvents = 1000;
+    private static final int waitMs = 500;
+
+    @BeforeMethod
+    public void setUp() {
+        log.info("In setUp()");
+        parsedUdpEvents = new ArrayList<>();
+        kafkaIngressEvents = new ArrayList<>();
+        testTopic = UUID.randomUUID().toString();
+
+        final SiddhiManager siddhiManager = new SiddhiManager();
+        createSrcUdpAppRuntime(siddhiManager);
+        createKafkaIngressAppRuntime(siddhiManager);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        log.info("In tearDown()");
+        try {
+            srcUdpSiddhiAppRuntime.shutdown();
+            kafkaIngressSiddhiAppRuntime.shutdown();
+        } finally {
+            // Delete topic
+            final Properties conf = new Properties();
+            conf.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+            conf.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "5000");
+            final AdminClient client = AdminClient.create(conf);
+            log.info("Deleting testTopic - " + testTopic);
+            client.deleteTopics(Collections.singletonList(testTopic));
+            client.close();
+        }
+
+        log.info("Siddhi App Runtime down");
+    }
+
+    /**
+     * Tests to ensure that UDP IPv4 two hop Telemetry Report packets can be converted to JSON, sent out and received
+     * back via Kafka.
+     */
+    @Test
+    public void testTelemetryReportUdp4() {
+        runTest(TestTelemetryReports.UDP4_2HOPS);
+    }
+
+    /**
+     * Tests to ensure that TCP IPv4 two hop Telemetry Report packets can be converted to JSON, sent out and received
+     * back via Kafka.
+     */
+    @Test
+    public void testTelemetryReportTcp4() {
+        runTest(TestTelemetryReports.TCP4_2HOPS);
+    }
+
+    /**
+     * Tests to ensure that UDP IPv6 two hop Telemetry Report packets can be converted to JSON, sent out and received
+     * back via Kafka.
+     */
+    @Test
+    public void testTelemetryReportUdp6() {
+        runTest(TestTelemetryReports.UDP6_2HOPS);
+    }
+
+    /**
+     * Tests to ensure that TCP IPv4 two hop Telemetry Report packets can be converted to JSON, sent out and received
+     * back via Kafka.
+     */
+    @Test
+    public void testTelemetryReportTcp6() {
+        runTest(TestTelemetryReports.TCP6_2HOPS);
+    }
+
+    /**
+     * Executes the test against the byte array.
+     * @param bytes - the packet UDP payload (the TelemetryReport bytes)
+     * @throws Exception
+     */
+    private void runTest(final byte[] bytes) {
+        try {
+            sendTestEvents(bytes, numTestEvents);
+
+            // Wait a short bit for the processing to complete
+            Thread.sleep(waitMs);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals(numTestEvents, kafkaIngressEvents.size());
+        Assert.assertEquals(numTestEvents, parsedUdpEvents.size());
+
+        validateTelemetryReports();
+    }
+
+    /**
+     * Method responsible for starting the kafka source Siddhi script with "json" mapper.
+     * TODO - Properly define trptJsonStream and write one DDoS query
+     * TODO - Add HTTP sink for making web service call to mock SDN controller
+     * @param siddhiManager - the Siddhi manager to leverage
+     */
+    private void createKafkaIngressAppRuntime(final SiddhiManager siddhiManager) {
+        final String udpSourceDefinition = String.format(
+                "@app:name('Kafka-Source-TRPT')\n" +
+                    "@source(type='kafka', topic.list='%s', bootstrap.servers='%s', group.id='test',\n" +
+                    "threading.option='single.thread',\n" +
+                        // TODO - Move mapper class and tests to the p4-map project
+                        "@map(type='p4-trpt-json',\n" +
+                            "@attributes(domainId='telemRptHdr.domainId', dstAddr='ipHdr.dstAddr',\n" +
+                                "dstPort='dstPort')))\n" +
+                    "@sink(type='file', file.uri='/tmp/alerts.out', @map(type='text'))\n" +
+                    "define stream trptJsonStream (domainId long, dstAddr string, dstPort long);",
+                testTopic, kafkaServer);
+        final String udpSourceQuery =
+                "@info(name = 'sourceQuery')\n" +
+                    "from trptJsonStream\n" +
+                    "select *\n" +
+                    "insert into parsedTrpt;";
+        kafkaIngressSiddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(udpSourceDefinition + udpSourceQuery);
+        kafkaIngressSiddhiAppRuntime.addCallback("sourceQuery", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                kafkaIngressEvents.add(inEvents);
+            }
+        });
+        kafkaIngressSiddhiAppRuntime.start();
+    }
+
+    /**
+     * Method responsible for starting the UDP source siddhi script with the "p4-trpt" mapper and kafka sink with the
+     * "json" mapper.
+     * @param siddhiManager - the Siddhi manager to leverage
+     */
+    private void createSrcUdpAppRuntime(final SiddhiManager siddhiManager) {
+        final String udpSourceDefinition = String.format(
+                "@app:name('UDP-Source-TRPT')\n" +
+                    "@source(type='udp', listen.port='5556', @map(type='p4-trpt'))\n" +
+                    "@sink(type='kafka', topic='%s', bootstrap.servers='%s', @map(type='json'))\n" +
+                    " define stream trptUdpPktStream (telemRpt object);",
+                testTopic, kafkaServer);
+        final String udpSourceQuery =
+                "@info(name = 'sourceQuery')\n" +
+                    "from trptUdpPktStream\n" +
+                    "select *\n" +
+                    "insert into distTrptJson;";
+        srcUdpSiddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(udpSourceDefinition + udpSourceQuery);
+        srcUdpSiddhiAppRuntime.addCallback("sourceQuery", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                parsedUdpEvents.add(inEvents);
+            }
+        });
+        srcUdpSiddhiAppRuntime.start();
+    }
+
+    private void sendTestEvents(final byte[] eventBytes, final int numTestEvents) throws Exception {
+        for (int ctr = 0; ctr < numTestEvents; ctr++) {
+            final InetAddress address = InetAddress.getByName("localhost");
+            final DatagramPacket packet = new DatagramPacket(eventBytes, 0, eventBytes.length,
+                    address, 5556);
+            final DatagramSocket datagramSocket = new DatagramSocket();
+            datagramSocket.send(packet);
+            Thread.sleep(1, 1000);
+        }
+    }
+
+    private void validateTelemetryReports() {
+        for (final Event[] events : parsedUdpEvents) {
+            for (final Event event : events) {
+                validateEvent(event);
+            }
+        }
+//        for (final Event[] events : kafkaIngressEvents) {
+//            for (final Event event : events) {
+//                validateEvent(event);
+//            }
+//        }
+    }
+
+    private void validateEvent(final Event event) {
+        final String eventStr = (String) event.getData()[0];
+        final JsonParser parser = new JsonParser();
+        final JsonElement jsonElement = parser.parse(eventStr);
+        final JsonObject trptJsonObj = jsonElement.getAsJsonObject();
+        Assert.assertNotNull(trptJsonObj);
+        final JsonObject trptHdrJson = trptJsonObj.get("telemRptHdr").getAsJsonObject();
+        Assert.assertNotNull(trptHdrJson);
+        Assert.assertEquals(2, trptHdrJson.get(TelemetryReportHeader.TRPT_VER_KEY).getAsInt());
+        Assert.assertEquals(234, trptHdrJson.get(TelemetryReportHeader.TRPT_NODE_ID_KEY).getAsLong());
+        Assert.assertEquals(21587, trptHdrJson.get(TelemetryReportHeader.TRPT_DOMAIN_ID_KEY).getAsLong());
+    }
+
+}

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -3,8 +3,8 @@
 <suite name="Siddhi-Map-P4Trpt-Test-Suite">
     <test name="Siddhi-map-p4-trpt-tests" enabled="true" preserve-order="true" parallel="false">
         <classes>
-            <class name="io.siddhi.extension.map.p4.trpt.sinkmapper.TestCaseOfP4TrptSinkMapper"/>
-            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.TelemetryReportByteParsingTests"/>
+            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.UDPSourceKafkaSinkTelemetryReportTestCase"/>
+            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.UDPSourceToKafkaSourceTelemetryReportTestCase"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </modules>
 
     <properties>
-        <siddhi.version>5.0.0</siddhi.version>
+        <siddhi.version>5.1.14</siddhi.version>
         <log4j.version>1.2.17</log4j.version>
         <testng.version>6.8</testng.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>


### PR DESCRIPTION
Makes much more sense from a dependency management and logical point-of-view to run any P4 Telemetry Report specific logic here rather than in the new UDP I/O extension