### PR TITLE
Downgrade several dependencies to match the K8s siddhi-operator

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.siddhi.extension.map.json</groupId>
             <artifactId>siddhi-map-json</artifactId>
-            <version>5.2.1</version>
+            <version>5.0.6</version>
             <type>bundle</type>
         </dependency>
         <dependency>
@@ -60,26 +60,26 @@
         <dependency>
             <groupId>io.siddhi.extension.io.kafka</groupId>
             <artifactId>siddhi-io-kafka</artifactId>
-            <version>5.0.12</version>
+            <version>5.0.7</version>
             <type>bundle</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.siddhi.extension.io.file</groupId>
             <artifactId>siddhi-io-file</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.siddhi.extension.map.text</groupId>
             <artifactId>siddhi-map-text</artifactId>
-            <version>2.1.0</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.siddhi.extension.io.http</groupId>
             <artifactId>siddhi-io-http</artifactId>
-            <version>2.3.3</version>
+            <version>2.2.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -10,13 +10,13 @@
 <!--        </classes>-->
     </test>
     <test name="Siddhi-map-p4-trpt-tests" enabled="true" parallel="false">
-        <packages>
-            <package name="io.siddhi.extension.map.p4.trpt.sourcemapper.*"></package>
-        </packages>
-<!--        <classes>-->
+<!--        <packages>-->
+<!--            <package name="io.siddhi.extension.map.p4.trpt.sourcemapper.*"></package>-->
+<!--        </packages>-->
+        <classes>
 <!--            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.UDPSourceKafkaSinkTelemetryReportTestCase"/>-->
-<!--            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.UDPSourceToKafkaSourceTelemetryReportTestCase"/>-->
-<!--            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.SimpleDDoSAlertTestCase"/>-->
-<!--        </classes>-->
+            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.UDPSourceToKafkaSourceTelemetryReportTestCase"/>
+            <class name="io.siddhi.extension.map.p4.trpt.sourcemapper.SimpleDDoSAlertTestCase"/>
+        </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </modules>
 
     <properties>
-        <siddhi.version>5.1.14</siddhi.version>
+        <siddhi.version>5.1.11</siddhi.version>
         <log4j.version>1.2.17</log4j.version>
         <testng.version>6.8</testng.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>


### PR DESCRIPTION
After attempting to run the extension in K8s using the siddhi-operator, I wanted to ensure that these mvn dependencies were the same as the bundles delivered in the siddhi container image.